### PR TITLE
build fix for the agent forwarding branch

### DIFF
--- a/src/network/outofband.cc
+++ b/src/network/outofband.cc
@@ -321,3 +321,5 @@ string OutOfBandCommunicator::read(size_t len) {
   stream_buf = stream_buf.substr(len);
   return rv;
 }
+
+OutOfBandPlugin::~OutOfBandPlugin() { }

--- a/src/network/outofband.h
+++ b/src/network/outofband.h
@@ -125,6 +125,7 @@ namespace Network {
     virtual void close_sessions( void ) = 0;
     virtual void shutdown( void ) = 0;
     virtual void attach_oob(Network::OutOfBand *oob_ctl) = 0;
+    virtual ~OutOfBandPlugin() = 0;
 
     friend class OutOfBand;
   };


### PR DESCRIPTION
When trying to build a deb with agent forwarding support (thanks for this btw!) I encountered a `‘class Network::OutOfBandPlugin’ has virtual functions and accessible non-virtual destructor [-Werror=non-virtual-dtor]` build error.

I got around this by adding an empty virtual destructor to OutOfBandPlugin, however I can only assume that has no negative side effects. Tests pass and the resulting package works.
